### PR TITLE
corrected pronouns in messages.pl.yml

### DIFF
--- a/src/SuplaBundle/Resources/translations/messages.pl.yml
+++ b/src/SuplaBundle/Resources/translations/messages.pl.yml
@@ -166,8 +166,8 @@ Choose client apps: Wybierz aplikacje klienckie
 Choose location: Wybierz lokalizację
 Choose the source channel.: Wybierz kanał źródłowy.
 Clear: Wyczyść
-Click the following link to confirm removal of your account on %cloudHost%.: Aby potwierdzić chęć usunięcia Twojego konta na %cloudHost%, kliknij poniższy link.
-Click the following link to confirm unregistration of your private SUPLA Cloud instance (%targetCloudUrl%).: Kliknij poniższy link aby potwierdzić wyrejestrowanie twojej prywatnej instancji SUPLA Cloud (%targetCloudUrl%).
+Click the following link to confirm removal of your account on %cloudHost%.: Aby potwierdzić chęć usunięcia swojego konta na %cloudHost%, kliknij poniższy link.
+Click the following link to confirm unregistration of your private SUPLA Cloud instance (%targetCloudUrl%).: Kliknij poniższy link aby potwierdzić wyrejestrowanie swojej prywatnej instancji SUPLA Cloud (%targetCloudUrl%).
 'Client app ID: %clientAppId%': 'Identyfikator: %clientAppId%'
 Client registration: Rejestracja klientów
 Client’s Apps: Aplikacje klienckie
@@ -363,7 +363,7 @@ If you are a developer who wants to provide additional features for SUPLA, creat
 If you are sure you have an account on cloud.supla.org, check if the application you are trying to authorize is public.: Jeśli masz pewność, że posiadasz konto na cloud.supla.org, sprawdź, czy aplikacja, którą próbujesz autoryzować, jest publiczna.
 If you did not request this password reset, please ignore this information.: Jeżeli nie zażądałeś(aś) zresetowania hasła zignoruj tę wiadomość.
 If you do not want to delete your account on %cloudHost%, please do not click the link.: Jeżeli nie chcesz usuwać konta w serwisie %cloudHost%, nie klikaj odnośnika.
-If you do not want to unregister your instance, please do not click the link.: Jeśli nie chcesz wyrejestrować twojej instancji, nie klikaj linku.
+If you do not want to unregister your instance, please do not click the link.: Jeśli nie chcesz wyrejestrować swojej instancji, nie klikaj linku.
 If you fail to connect this AP for several minutes, it will restart itself and use the last settings.: Jeśli nie uda Ci się połączyć z tym punktem dostępowym przez kilka minut, urządzenie zrestartuje się i połączy używając ostatnich ustawień.
 If you have doubts or more questions, you can contact us directly at %securityEmail%.: Jeśli masz wątpliwości lub pytania, możesz się z nami skontaktować pisząc na adres %securityEmail%.
 If you have lost your instance token and you are going to re-register your instance, it's the right thing to do.: Jeśli chcesz ponownie zarejestrować twoją instancję SUPLA Cloud, ponieważ token wygenerowany przy poprzedniej rejestracji zaginął - jesteś w dobrym miejscu.
@@ -379,7 +379,7 @@ If you wish to see the available integrations, go to {0}.: Jeśli chcesz zobaczy
 If you wish to unregister your instance, {clickHereLink}.: Jeśli chcesz wyrejestrować twoją instancję, {clickHereLink}.
 Impulse counter: Licznik impulsów
 Impulses: Impulsy
-In order to confirm account deletion, enter your password.: W celu potwierdzenia chęci usunięcia Twojego konta podaj swoje hasło.
+In order to confirm account deletion, enter your password.: W celu potwierdzenia chęci usunięcia swojego konta podaj swoje hasło.
 In order to get the MQTT Broker credentials, concact the administator of this SUPLA Cloud instance.: Aby uzyskać dane do logowania do brokera MQTT, skontaktuj się z administratorem tej instancji SUPLA Cloud.
 Inactive: Nieaktywny
 Include energy corrections in new measurements history (not recommended): Uwzględnij wartość dodaną w historii (niezalecane)
@@ -724,7 +724,7 @@ Thermostat: Termostat
 This direct link requires further parameters in order to be executed properly. See the examples below to get an idea of what you might do.: Ten link bezpośredni wymaga doprecyzowania parametrów wykonywanej akcji. Zobacz poniższe przykłady aby dowiedzieć się, jakie parametry możesz ustawić.
 This information has been generated automatically due to an unsuccessful login attempt to SUPLA-CLOUD (%cloudHost%) with the use of your email address.: Otrzymujesz tę informację w związku z nieudaną próbą logowania do SUPLA-CLOUD (%cloudHost%) przy użyciu Twojego adresu email.
 This is the final step in the deletion process. Completing the form will result in an irreversible data loss.: To jest ostatni etap usuwania Twojego konta. Wypełnienie i zatwierdzenie formularza będzie skutkować nieodwracalnym usunięciem Twoich danych.
-This is the list of applications you have granted access to your account.: To jest lista aplikacji, którym udzieliłeś(aś) dostępu do Twojego konta.
+This is the list of applications you have granted access to your account.: To jest lista aplikacji, którym udzieliłeś(aś) dostępu do swojego konta.
 This link is only valid for an hour.: Link będzie aktywny przez godzinę.
 This schedule mode is meant to be used by advanced or patient users only. You need to specify schedule execution behavior in a Crontab notation (extended by some SUPLA flavours). You may find the crontab.guru website helpful, if you have not came across crontabs yet.: Ten tryb harmonogramu jest zaprojektowany z myślą o technicznych lub bardzo cierpliwych użytkownikach. Wymaga on podania momentów wyzwalania harmonogramu w notacji crontab, wzbogaconej o kilka funkcjonalności spotykanych tylko w SUPLI. Jeśli nie spotkałeś/aś się wcześniej z crontabami a nadal chcesz użyć tego trybu, strona crontab.guru może się okazać dla Ciebie pomocna.
 This trigger is used by the device itself (e.g. it turns on the light or starts the roller shutter). Setting any action on this trigger will disable the local function.: Ten wyzwalacz jest używany lokalnie przez urządzenie (np. włącza światło, steruje roletą itd.) Jeśli przypiszesz mu inną akcję, to lokalna funkcja zostanie wyłączona.
@@ -807,7 +807,7 @@ You cannot delete your last access identifier.: Nie możesz usunąć swojego ost
 You cannot delete your last location.: Nie możesz usunać swojej ostatniej lokalizacji.
 You cannot use SUPLA project name in the domain name.: Nie możesz używać nazwy projektu SUPLA w nazwie głównej domeny.
 You have exceeded your API Rate Limit: Wykorzystałeś/aś swój limit żądań do API
-You have requested to unregister your SUPLA Cloud instance: Poprosiłeś/aś o wyrejestrowanie twojej instancji SUPLA Cloud
+You have requested to unregister your SUPLA Cloud instance: Poprosiłeś/aś o wyrejestrowanie swojej instancji SUPLA Cloud
 You have to choose at least one scope.: Musisz wybrać przynajmniej jeden zakres.
 You just need to execute the following command inside your host terminal.: Wystarczy wykonać następujące polecenie wewnątrz terminala Twojego hosta.
 You may find the below examples helpful, provided that you are still willing to use the advanced schedule mode.: Jeśli nadal chcesz skorzystać z zaawansowanego trybu harmonogramu, rzuć okiem na poniższe przykłady.
@@ -988,7 +988,7 @@ Email already exists: Adres e-mail już istnieje
 Execute the scene: Wykonaj scenę
 Existing schedules: Istniejące harmonogramy
 Generic action: Inna akcja
-Get SUPLA on your devices: Pobierz SUPLĘ na Twoje urządzenia
+Get SUPLA on your devices: Pobierz SUPLĘ na swoje urządzenia
 Hi: Cześć
 Hour: Godzina
 Hours: Godziny


### PR DESCRIPTION
There were some mistakes when it comes to use of pronouns in polish translation.

W kilku frazach w polskim tłumaczeniu zostały użyte zaimki "twój" zamiast "swój". 
Poniżej przesyłam listę linijek, w których dokonałem korekty.

https://github.com/SUPLA/supla-cloud/blob/c4e3d2990134cb098afb608384494d41a6ce90ab/src/SuplaBundle/Resources/translations/messages.pl.yml#L169-L170

https://github.com/SUPLA/supla-cloud/blob/c4e3d2990134cb098afb608384494d41a6ce90ab/src/SuplaBundle/Resources/translations/messages.pl.yml#L366

https://github.com/SUPLA/supla-cloud/blob/c4e3d2990134cb098afb608384494d41a6ce90ab/src/SuplaBundle/Resources/translations/messages.pl.yml#L382

https://github.com/SUPLA/supla-cloud/blob/c4e3d2990134cb098afb608384494d41a6ce90ab/src/SuplaBundle/Resources/translations/messages.pl.yml#L727

https://github.com/SUPLA/supla-cloud/blob/c4e3d2990134cb098afb608384494d41a6ce90ab/src/SuplaBundle/Resources/translations/messages.pl.yml#L810

https://github.com/SUPLA/supla-cloud/blob/c4e3d2990134cb098afb608384494d41a6ce90ab/src/SuplaBundle/Resources/translations/messages.pl.yml#L991